### PR TITLE
Multipart Support

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -230,6 +230,11 @@ func prepareRequestBody(b interface{}) (io.Reader, error) {
 		return bytes.NewReader(b.([]byte)), nil
 	case nil:
 		return nil, nil
+	case MultipartForm:
+		mp := b.(MultipartForm)
+		return mp.ToReader()
+	case *MultipartForm:
+		return b.(*MultipartForm).ToReader()
 	default:
 		// try to jsonify it
 		j, err := json.Marshal(b)

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -850,8 +850,13 @@ func TestRequest(t *testing.T) {
 					Expect(r.Host).Should(Equal("foobar.com"))
 					Expect(r.Header.Get("Content-Type")).Should(Equal("multipart/mixed"))
 
-					b, _ := ioutil.ReadAll(r.Body)
+					b, err := ioutil.ReadAll(r.Body)
+					Expect(err).ShouldNot(HaveOccurred())
+					fmt.Println(string(b))
 					Expect(b).ShouldNot(HaveLen(0))
+					Expect(string(b)).Should(ContainSubstring(`Content-Disposition: form-data; name="something"`))
+					Expect(string(b)).Should(ContainSubstring(`Content-Disposition: form-data; name="file"; filename="mything.txt"`))
+					Expect(string(b)).Should(ContainSubstring(`Content-Type: application/octet-stream`))
 
 					w.WriteHeader(200)
 				}))

--- a/multipart.go
+++ b/multipart.go
@@ -22,6 +22,7 @@ import (
 //        Uri:          "http://some.place/uristuff",
 //        Method:       "POST",
 //        Body:         body,
+//        ContentType:  "multipart/mixed",
 //    }.Do()
 type MultipartForm struct {
 	Params   map[string]string

--- a/multipart.go
+++ b/multipart.go
@@ -1,0 +1,64 @@
+package goreq
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+)
+
+// MultipartForm wraps functionality from the stdlib mime/multipart
+// You can supply any io.Reader as the source, and goreq will send your
+// request as a multipart form. For convenience, you can set the
+// "FileName" attribute and that will be added to the field header
+
+// Simple usage to upload a file looks like this
+//    file, _ := os.Open("/tmp/myfile")
+//    body := goreq.MultipartForm{
+//        Field:    "file",
+//        FileName: "myfile",
+//        Source:   file,
+//    }
+//    resp, _ := goreq.Request{
+//        Uri:          "http://some.place/uristuff",
+//        Method:       "POST",
+//        Body:         body,
+//    }.Do()
+type MultipartForm struct {
+	Params   map[string]string
+	Field    string
+	Source   io.Reader
+	buffer   bytes.Buffer
+	FileName string
+}
+
+func (m *MultipartForm) ToReader() (_ io.Reader, err error) {
+	writer := multipart.NewWriter(&m.buffer)
+
+	for k, v := range m.Params { // fill in the extra form params
+		writer.WriteField(k, v)
+	}
+
+	var multipartWriter io.Writer
+
+	if m.FileName != "" {
+		multipartWriter, err = writer.CreateFormFile(m.Field, m.FileName)
+	} else {
+		multipartWriter, err = writer.CreateFormField(m.Field)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = io.Copy(multipartWriter, m.Source)
+	if err != nil {
+		return nil, err
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return &m.buffer, nil
+}


### PR DESCRIPTION
I've added some basic multipart form support. It works, but the API is (IMO) a little rough but could benefit from some feedback. 

Here's a full usage example for uploading a file, and here's a link to view the requests it produces http://requestb.in/nkp6grnk?inspect

``` go
package main

import (
        "github.com/franela/goreq"
        "io/ioutil"
        "os"
        "path"
)

func main() {
        // The Gutenberg project is *awesome*
        // http://www.gutenberg.org/ebooks/45269
        fileName := "Inventions_of_the_Great_War--A.Russell_Bond.mobi"
        file, err := os.Open(path.Join("/tmp", fileName))
        if err != nil {
                panic(err)
        }       

        defer file.Close()

        body := goreq.MultipartForm{
                Params: map[string]string{
                        "title":       "Inventions of the Great War",
                        "author":      "A. Russell Bond",
                        "description": "A Gutenberg project book originally found at http://www.gutenberg.org/ebooks/45269",
                },      
                Field:    "file",
                FileName: fileName,
                Source:   file,
        }       

        resp, _ := goreq.Request{
                Uri:          "http://requestb.in/nkp6grnk",
                MaxRedirects: 5,
                Method:       "POST",
                Body:         body,
        }.Do()  

        println(resp.StatusCode)
        b, _ := ioutil.ReadAll(resp.Body)
        println(string(b))
}
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/franela/goreq/41)

<!-- Reviewable:end -->
