### PR TITLE
Use a global transport and client to prevent leaking connections

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -153,14 +153,14 @@ func (r Request) Do() (*Response, error) {
 		return nil, &Error{Err: e}
 	}
 
-  if r.QueryString != nil {
-    param, e := paramParse(r.QueryString)
-    if e != nil {
-      return nil, &Error{Err: e}
-    }
-    r.Uri = r.Uri + "?" + param
-  }
-  req, er = http.NewRequest(r.Method, r.Uri, b)
+	if r.QueryString != nil {
+		param, e := paramParse(r.QueryString)
+		if e != nil {
+			return nil, &Error{Err: e}
+		}
+		r.Uri = r.Uri + "?" + param
+	}
+	req, er = http.NewRequest(r.Method, r.Uri, b)
 
 	if er != nil {
 		// we couldn't parse the URL.

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -225,9 +225,9 @@ func TestRequest(t *testing.T) {
 				g.It("Should do a POST with querystring", func() {
 					bdy := []byte{'f', 'o', 'o'}
 					res, err := Request{
-            Method: "POST",
+						Method:      "POST",
 						Uri:         ts.URL + "/getquery",
-            Body: bdy,
+						Body:        bdy,
 						QueryString: query,
 					}.Do()
 


### PR DESCRIPTION
Creating a new transport and client on every requests was creating a leaked connection on every request, this is solved using a global client and transport!
Plus, according to go documentation Clients and Transport should be reused, because they use cached connections an may be able to reuse them, so this is necessary if we want to support keep-alive connections in goreq (adding the header just works now)

Recap:
- No leaked connections
- Improved performance
- Support for persistant connections / keep-alive

PS: I've left support for specifying a custom transport in the request, but i think it should be removed, what do you think?
