### PR TITLE
Add ContentLength to Response struct

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -32,9 +32,10 @@ type Request struct {
 }
 
 type Response struct {
-	StatusCode int
-	Body       Body
-	Header     http.Header
+	StatusCode    int
+	ContentLength int64
+	Body          Body
+	Header        http.Header
 }
 
 type headerTuple struct {
@@ -118,7 +119,7 @@ func prepareRequestBody(b interface{}) (io.Reader, error) {
 }
 
 func newResponse(res *http.Response) *Response {
-	return &Response{StatusCode: res.StatusCode, Header: res.Header, Body: Body{res.Body}}
+	return &Response{StatusCode: res.StatusCode, ContentLength: res.ContentLength, Header: res.Header, Body: Body{res.Body}}
 }
 
 var dialer = &net.Dialer{Timeout: 1000 * time.Millisecond}

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -101,6 +101,16 @@ func TestRequest(t *testing.T) {
 					Expect(res.StatusCode).Should(Equal(200))
 				})
 
+				g.It("Should return ContentLength", func() {
+					res, err := Request{Uri: ts.URL + "/foo"}.Do()
+
+					Expect(err).Should(BeNil())
+					str, _ := res.Body.ToString()
+					Expect(str).Should(Equal("bar"))
+					Expect(res.StatusCode).Should(Equal(200))
+					Expect(res.ContentLength).Should(Equal(int64(3)))
+				})
+
 				g.It("Should do a GET with querystring", func() {
 					res, err := Request{
 						Uri:         ts.URL + "/getquery",


### PR DESCRIPTION
It allows for a more performant read on the body by doing:

```
body := make([]byte, 0, res.ContentLength)
_, err := io.ReadFull(res.Body, body)
```
