### PR TITLE
make Do() return a goreq Error object

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -136,7 +136,7 @@ func (r *Request) AddHeader(name string, value string) {
 	r.headers = append(r.headers, headerTuple{name: name, value: value})
 }
 
-func (r Request) Do() (*Response, error) {
+func (r Request) Do() (*Response, *Error) {
 	var req *http.Request
 	var er error
 


### PR DESCRIPTION
Do() was coercing Goreq's Error object to 'error', leaving users unable to access Timeout information from Goreq's Error object.
