### PR TITLE
Add proxy support

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -32,7 +32,7 @@ type Request struct {
 	Insecure     bool
 	MaxRedirects int
 	Compression  string
-  Proxy        string
+	Proxy        string
 }
 
 type Response struct {
@@ -159,22 +159,22 @@ func (r *Request) AddHeader(name string, value string) {
 func (r Request) Do() (*Response, error) {
 	var req *http.Request
 	var er error
-  var transport = defaultTransport
-  var client = defaultClient
+	var transport = defaultTransport
+	var client = defaultClient
 
-  if r.Proxy != "" {
-    proxyUrl, err := url.Parse(r.Proxy)
-    if err != nil {
-      // proxy address is in a wrong format
-      return nil, &Error{Err: err}
-    }
-    if proxyTransport == nil {
-      proxyTransport = &http.Transport{Dial: defaultDialer.Dial, Proxy: http.ProxyURL(proxyUrl)}
-      proxyClient = &http.Client{Transport: proxyTransport}
-    }
-    transport = proxyTransport
-    client = proxyClient
-  }
+	if r.Proxy != "" {
+		proxyUrl, err := url.Parse(r.Proxy)
+		if err != nil {
+			// proxy address is in a wrong format
+			return nil, &Error{Err: err}
+		}
+		if proxyTransport == nil {
+			proxyTransport = &http.Transport{Dial: defaultDialer.Dial, Proxy: http.ProxyURL(proxyUrl)}
+			proxyClient = &http.Client{Transport: proxyTransport}
+		}
+		transport = proxyTransport
+		client = proxyClient
+	}
 
 	if r.Insecure {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -689,33 +689,33 @@ func TestRequest(t *testing.T) {
 			})
 		})
 
-    g.Describe("Proxy", func() {
+		g.Describe("Proxy", func() {
 			var ts *httptest.Server
-      var lastReq *http.Request
-      g.Before(func() {
+			var lastReq *http.Request
+			g.Before(func() {
 				ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == "GET" && r.URL.Path == "/" {
-            lastReq = r
+						lastReq = r
 						w.Header().Add("x-forwarded-for", "test")
 						w.WriteHeader(200)
-            w.Write([]byte(""))
+						w.Write([]byte(""))
 					}
 				}))
-      })
+			})
 
-      g.After(func() {
-        ts.Close()
-      })
+			g.After(func() {
+				ts.Close()
+			})
 
-      g.It("Should use Proxy", func () {
-        proxiedHost := "www.google.com"
-        res, err := Request{Uri: "http://" + proxiedHost, Proxy: ts.URL}.Do()
-        Expect(err).Should(BeNil())
-        Expect(res.Header.Get("x-forwarded-for")).Should(Equal("test"))
-        Expect(lastReq).ShouldNot(BeNil())
-        Expect(lastReq.Host).Should(Equal(proxiedHost))
-      })
+			g.It("Should use Proxy", func() {
+				proxiedHost := "www.google.com"
+				res, err := Request{Uri: "http://" + proxiedHost, Proxy: ts.URL}.Do()
+				Expect(err).Should(BeNil())
+				Expect(res.Header.Get("x-forwarded-for")).Should(Equal("test"))
+				Expect(lastReq).ShouldNot(BeNil())
+				Expect(lastReq.Host).Should(Equal(proxiedHost))
+			})
 
-    })
+		})
 	})
 }


### PR DESCRIPTION
Added proxy support and a test to support it works, it's basically a copy-paste from the test linked by @marcosnils  from node's request library
It's heavily based on @giefferre work.

I've created another client and transport, initially empty, that are initialized and used whenever a request specifies a Proxy.
Default transport now inherits proxy environment variables.

Cheers!
