### PR TITLE
Connection timeouts aren't correctly identified.

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -298,11 +298,17 @@ func (r Request) Do() (*Response, error) {
 	}
 
 	if err != nil {
-		if op, ok := err.(*url.Error); !timeout && ok {
-			if op1, ok := op.Err.(*net.OpError); ok {
-				timeout = op1.Timeout()
+		if !timeout {
+			switch err := err.(type) {
+			case *net.OpError:
+				timeout = err.Timeout()
+			case *url.Error:
+				if op, ok := err.Err.(*net.OpError); ok {
+					timeout = op.Timeout()
+				}
 			}
 		}
+
 		return nil, &Error{timeout: timeout, Err: err}
 	}
 

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -658,6 +658,21 @@ func TestRequest(t *testing.T) {
 					Expect(res).Should(BeNil())
 					Expect(err.(*Error).Timeout()).Should(BeTrue())
 				})
+				g.It("Should connect timeout after a custom amount of time even with method set", func() {
+					SetConnectTimeout(100 * time.Millisecond)
+					start := time.Now()
+					request := Request{
+						Uri:    "http://10.255.255.1",
+						Method: "GET",
+					}
+					res, err := request.Do()
+					elapsed := time.Since(start)
+
+					Expect(elapsed).Should(BeNumerically("<", 150*time.Millisecond))
+					Expect(elapsed).Should(BeNumerically(">=", 100*time.Millisecond))
+					Expect(res).Should(BeNil())
+					Expect(err.(*Error).Timeout()).Should(BeTrue())
+				})
 			})
 
 			g.Describe("Request timeout", func() {
@@ -767,8 +782,7 @@ func TestRequest(t *testing.T) {
 				Expect(err).ShouldNot(BeNil())
 			})
 			g.It("Should handle DNS errors", func() {
-				_, err := Request{Uri: "http://*.localhost"}.Do()
-
+				_, err := Request{Uri: "http://.localhost"}.Do()
 				Expect(err).ShouldNot(BeNil())
 			})
 		})


### PR DESCRIPTION
Hey so I was having some issues with dial tcp i/o timeout. I took a closer look and it seems like the error that your client returns is a url.Error wrapping a net.OpError. Its seems a little weird but the patch that I put in here seems to work. If you want to test it out just hack your hosts and put in an ip that doesn't have the fw open or the like. I can dig a little deeper here if you need/want. Or try and explain this better. Anyway double check me and let me know if this is appropriate. Love the lib thanks.
