### PR TITLE
Remove basic auth password requirement.

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -279,7 +279,7 @@ func (r Request) Do() (*Response, error) {
 	}
 
 	//use basic auth if required
-	if r.BasicAuthUsername != "" && r.BasicAuthPassword != "" {
+	if r.BasicAuthUsername != "" {
 		req.SetBasicAuth(r.BasicAuthUsername, r.BasicAuthPassword)
 	}
 


### PR DESCRIPTION
There isn't a strict requirement for a password, since the basic auth token can be computed regardless. It's also my understanding authentication using basic auth relying solely on an API key is fairly common.
