### PR TITLE
Debug support

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,29 @@ res, err := goreq.Request{
 }.Do()
 ```
 
+##Debug
+If you need to debug your http requests, it can print the http request detail.
+
+```go
+res, err := goreq.Request{
+	Method:      "GET",
+	Uri:         "http://www.google.com",
+	Compression: goreq.Gzip(),
+	ShowDebug:   true,
+}.Do()
+fmt.Println(res, err)
+```
+
+and it will print the log:
+```
+GET / HTTP/1.1
+Host: www.google.com
+Accept:
+Accept-Encoding: gzip
+Content-Encoding: gzip
+Content-Type:
+```
+
 TODO:
 -----
 

--- a/goreq.go
+++ b/goreq.go
@@ -330,9 +330,9 @@ func (r Request) Do() (*Response, error) {
 	if r.ShowDebug {
 		dump, err := httputil.DumpRequest(req, true)
 		if err != nil {
-			println(err.Error())
+			fmt.Println(err.Error())
 		}
-		println(string(dump))
+		fmt.Println(string(dump))
 	}
 
 	res, err := client.Do(req)
@@ -378,10 +378,6 @@ func (r Request) addHeaders(headersMap http.Header) {
 	}
 	headersMap.Add("Accept", r.Accept)
 	headersMap.Add("Content-Type", r.ContentType)
-}
-
-func (r Request) Debug(is_debug bool) {
-	r.ShowDebug = is_debug
 }
 
 // Return value if nonempty, def otherwise.

--- a/goreq.go
+++ b/goreq.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -330,9 +331,9 @@ func (r Request) Do() (*Response, error) {
 	if r.ShowDebug {
 		dump, err := httputil.DumpRequest(req, true)
 		if err != nil {
-			fmt.Println(err.Error())
+			log.Println(err)
 		}
-		fmt.Println(string(dump))
+		log.Println(string(dump))
 	}
 
 	res, err := client.Do(req)

--- a/goreq.go
+++ b/goreq.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"reflect"
 	"strings"
@@ -38,6 +39,7 @@ type Request struct {
 	Compression       *compression
 	BasicAuthUsername string
 	BasicAuthPassword string
+	ShowDebug         bool
 }
 
 type compression struct {
@@ -325,6 +327,14 @@ func (r Request) Do() (*Response, error) {
 		})
 	}
 
+	if r.ShowDebug {
+		dump, err := httputil.DumpRequest(req, true)
+		if err != nil {
+			println(err.Error())
+		}
+		println(string(dump))
+	}
+
 	res, err := client.Do(req)
 	if timer != nil {
 		timer.Stop()
@@ -368,6 +378,10 @@ func (r Request) addHeaders(headersMap http.Header) {
 	}
 	headersMap.Add("Accept", r.Accept)
 	headersMap.Add("Content-Type", r.ContentType)
+}
+
+func (r Request) Debug(is_debug bool) {
+	r.ShowDebug = is_debug
 }
 
 // Return value if nonempty, def otherwise.


### PR DESCRIPTION
I've add debug support for goreq by using the package net/http/httputil. Here is the example:

```go
package main

import (
	"fmt"
	"github.com/mnhkahn/goreq"
)

func main() {
	res, err := goreq.Request{
		Method:      "GET",
		Uri:         "http://www.google.com",
		Compression: goreq.Gzip(),
		ShowDebug:   true,
	}.Do()
	fmt.Println(res, err)
}
```

Here's the log.
```
GET / HTTP/1.1
Host: www.google.com
Accept:
Accept-Encoding: gzip
Content-Encoding: gzip
Content-Type:
```