### PR TITLE
Attach final URL of the Response after redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ return err
 If you don't get an error, you can safely use the ```Response```.
 
 ```go
-res.StatusCode //return the status code of the response
+res.Uri // return final URL location of the response (fulfilled after redirect was made)
+res.StatusCode // return the status code of the response
 res.Body // gives you access to the body
 res.Body.ToString() // will return the body as a string
 res.Header.Get("Content-Type") // gives you access to all the response headers

--- a/goreq.go
+++ b/goreq.go
@@ -50,6 +50,7 @@ type compression struct {
 }
 
 type Response struct {
+	Uri           string
 	StatusCode    int
 	ContentLength int64
 	Body          *Body
@@ -218,6 +219,7 @@ func (r Request) Do() (*Response, error) {
 	var er error
 	var transport = defaultTransport
 	var client = defaultClient
+	var resUri string
 	var redirectFailed bool
 
 	r.Method = valueOrDefault(r.Method, "GET")
@@ -243,6 +245,8 @@ func (r Request) Do() (*Response, error) {
 			redirectFailed = true
 			return errors.New("Error redirecting. MaxRedirects reached")
 		}
+
+		resUri = req.URL.String()
 
 		//By default Golang will not redirect request headers
 		// https://code.google.com/p/go/issues/detail?id=4800&q=request%20header
@@ -356,7 +360,7 @@ func (r Request) Do() (*Response, error) {
 		var response *Response
 		//If redirect fails we still want to return response data
 		if redirectFailed {
-			response = &Response{StatusCode: res.StatusCode, ContentLength: res.ContentLength, Header: res.Header, Body: &Body{reader: res.Body}}
+			response = &Response{Uri: resUri, StatusCode: res.StatusCode, ContentLength: res.ContentLength, Header: res.Header, Body: &Body{reader: res.Body}}
 		}
 
 		return response, &Error{timeout: timeout, Err: err}
@@ -367,9 +371,9 @@ func (r Request) Do() (*Response, error) {
 		if err != nil {
 			return nil, &Error{Err: err}
 		}
-		return &Response{StatusCode: res.StatusCode, ContentLength: res.ContentLength, Header: res.Header, Body: &Body{reader: res.Body, compressedReader: compressedReader}}, nil
+		return &Response{Uri: resUri, StatusCode: res.StatusCode, ContentLength: res.ContentLength, Header: res.Header, Body: &Body{reader: res.Body, compressedReader: compressedReader}}, nil
 	} else {
-		return &Response{StatusCode: res.StatusCode, ContentLength: res.ContentLength, Header: res.Header, Body: &Body{reader: res.Body}}, nil
+		return &Response{Uri: resUri, StatusCode: res.StatusCode, ContentLength: res.ContentLength, Header: res.Header, Body: &Body{reader: res.Body}}, nil
 	}
 }
 

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -90,6 +90,9 @@ func TestRequest(t *testing.T) {
 					if r.Method == "GET" && r.URL.Path == "/redirect_test/307" {
 						http.Redirect(w, r, "/getquery", 307)
 					}
+					if r.Method == "GET" && r.URL.Path == "/redirect_test/destination" {
+						http.Redirect(w, r, ts.URL+"/destination", 301)
+					}
 					if r.Method == "GET" && r.URL.Path == "/compressed" {
 						defer r.Body.Close()
 						b := "{\"foo\":\"bar\",\"fuu\":\"baz\"}"
@@ -656,6 +659,14 @@ func TestRequest(t *testing.T) {
 						MaxRedirects: 4,
 					}.Do()
 					Expect(res.StatusCode).Should(Equal(200))
+				})
+
+				g.It("Should return final URL of the response when redirecting", func() {
+					res, _ := Request{
+						Uri:          ts.URL + "/redirect_test/destination",
+						MaxRedirects: 2,
+					}.Do()
+					Expect(res.Uri).Should(Equal(ts.URL + "/destination"))
 				})
 			})
 		})


### PR DESCRIPTION
Follow-up from #69 / #70

I used to follow the redirects manually then I updated this lib to its latest and everything broke in my crawler `;]`

Example:
```go
package main

import (
    "log"

    "github.com/franela/goreq"
)

func main() {
    // this is explicit redirect but many websites are broken and have less obvious redirects
    u := "http://httpbin.org/redirect-to?url=http://golang.org/"

    res, err := goreq.Request{
        Uri:          u,
        MaxRedirects: 2,
    }.Do()

    if err != nil {
        log.Print(err)
        return
    }

    // further investigation of the URL is needed
    // above url was a redirect and doesn't reflect the current URL we're dealing with
    log.Print("What's the response's URL?!?")
}
```

So this PR keeps the final URL (but only after redirecting) and makes it available on `Response`
```go
        ...
        log.Printf("Here's the current URL: %s", res.Uri)
```

I am little Gopher noob TBH so let me know if this PR is rubbish!