### PR TITLE
paramParse: support annotated fields

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -157,10 +157,22 @@ func paramParse(query interface{}) (string, error) {
 		}
 		if t.Kind() == reflect.Struct {
 			for i := 0; i < t.NumField(); i++ {
-				if !s.Field(i).CanInterface() {
+				var name string
+
+				field := s.Field(i)
+				typeField := t.Field(i)
+
+				if !field.CanInterface() {
 					continue
 				}
-				v.Add(strings.ToLower(t.Field(i).Name), fmt.Sprintf("%v", s.Field(i).Interface()))
+
+				if urlTag := typeField.Tag.Get("url"); urlTag != "" {
+					name = urlTag
+				} else {
+					name = strings.ToLower(typeField.Name)
+				}
+
+				v.Add(name, fmt.Sprintf("%v", field.Interface()))
 			}
 			return v.Encode(), nil
 		} else {

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -1052,9 +1052,15 @@ func Test_paramParse(t *testing.T) {
 		B string
 		c string
 	}
+
+	type AnnotedForm struct {
+		Foo string `url:"foo_bar"`
+	}
+
 	g := Goblin(t)
 	RegisterFailHandler(func(m string, _ ...int) { g.Fail(m) })
 	var form = Form{}
+	var aform = AnnotedForm{}
 	var values = url.Values{}
 	const result = "a=1&b=2"
 	g.Describe("QueryString ParamParse", func() {
@@ -1062,6 +1068,7 @@ func Test_paramParse(t *testing.T) {
 			form.A = "1"
 			form.B = "2"
 			form.c = "3"
+			aform.Foo = "xyz"
 			values.Add("a", "1")
 			values.Add("b", "2")
 		})
@@ -1069,6 +1076,11 @@ func Test_paramParse(t *testing.T) {
 			str, err := paramParse(form)
 			Expect(err).Should(BeNil())
 			Expect(str).Should(Equal(result))
+		})
+		g.It("Should accept struct and use the field annotations", func() {
+			str, err := paramParse(aform)
+			Expect(err).Should(BeNil())
+			Expect(str).Should(Equal("foo_bar=xyz"))
 		})
 		g.It("Should accept pointer of struct", func() {
 			str, err := paramParse(&form)


### PR DESCRIPTION
This allows one to use:

```go
type Item struct {
        TheLimit int `url:"the_limit"`
        TheSkip int `url:"the_skip"`
        TheFields string `url:"the_field"`
}

item := Item {
        TheLimit: 3,
        TheSkip: 5,
        TheFields: "Value",
}

res, err := goreq.Request{
        Uri: "http://localhost:3000/",
        QueryString: item,
}.Do()
```

The traditional way to write Go is to use CamelCase (e.g. `FooBar` instead of `Foo_bar`) but some APIs use parameters in Snake_case (e.g. `who_am_i` instead of `WhoAmI`).