### PR TITLE
Embed *http.Response into Response as many of the fields we were using

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Simple and sane HTTP request library for Go language.
     - [Using compressed responses:](#user-content-using-compressed-responses)
  - [Proxy](#proxy)
  - [Debugging requests](#debug)
+     - [Getting raw Request & Response](#getting-raw-request--response)
  - [TODO:](#user-content-todo)
 
 
@@ -344,6 +345,39 @@ Accept-Encoding: gzip
 Content-Encoding: gzip
 Content-Type:
 ```
+
+
+### Getting raw Request & Response 
+
+To get the Request:
+
+```go
+req := Request{
+        Host: "foobar.com",
+}
+
+//req.Request will return a new instance of an http.Request so you can safely use it for something else
+request, _ := req.NewRequest()
+
+```
+
+
+To get the Response:
+
+```go
+res, err := goreq.Request{
+	Method:      "GET",
+	Uri:         "http://www.google.com",
+	Compression: goreq.Gzip(),
+	ShowDebug:   true,
+}.Do()
+
+// res.Response will contain the original http.Response structure 
+fmt.Println(res.Response, err)
+```
+
+
+
 
 TODO:
 -----

--- a/goreq.go
+++ b/goreq.go
@@ -52,11 +52,10 @@ type compression struct {
 }
 
 type Response struct {
-	Uri           string
-	StatusCode    int
-	ContentLength int64
-	Body          *Body
-	Header        http.Header
+	*http.Response
+	Uri  string
+	Body *Body
+	Raw  *http.Response
 }
 
 type headerTuple struct {
@@ -409,7 +408,7 @@ func (r Request) Do() (*Response, error) {
 		var response *Response
 		//If redirect fails we still want to return response data
 		if redirectFailed {
-			response = &Response{Uri: resUri, StatusCode: res.StatusCode, ContentLength: res.ContentLength, Header: res.Header, Body: &Body{reader: res.Body}}
+			response = &Response{res, resUri, &Body{reader: res.Body}, res}
 		}
 
 		//If redirect fails and we haven't set a redirect count we shouldn't return an error
@@ -425,9 +424,9 @@ func (r Request) Do() (*Response, error) {
 		if err != nil {
 			return nil, &Error{Err: err}
 		}
-		return &Response{Uri: resUri, StatusCode: res.StatusCode, ContentLength: res.ContentLength, Header: res.Header, Body: &Body{reader: res.Body, compressedReader: compressedReader}}, nil
+		return &Response{res, resUri, &Body{reader: res.Body, compressedReader: compressedReader}, res}, nil
 	} else {
-		return &Response{Uri: resUri, StatusCode: res.StatusCode, ContentLength: res.ContentLength, Header: res.Header, Body: &Body{reader: res.Body}}, nil
+		return &Response{res, resUri, &Body{reader: res.Body}, res}, nil
 	}
 }
 

--- a/goreq.go
+++ b/goreq.go
@@ -55,7 +55,6 @@ type Response struct {
 	*http.Response
 	Uri  string
 	Body *Body
-	Raw  *http.Response
 }
 
 type headerTuple struct {
@@ -408,7 +407,7 @@ func (r Request) Do() (*Response, error) {
 		var response *Response
 		//If redirect fails we still want to return response data
 		if redirectFailed {
-			response = &Response{res, resUri, &Body{reader: res.Body}, res}
+			response = &Response{res, resUri, &Body{reader: res.Body}}
 		}
 
 		//If redirect fails and we haven't set a redirect count we shouldn't return an error
@@ -424,9 +423,9 @@ func (r Request) Do() (*Response, error) {
 		if err != nil {
 			return nil, &Error{Err: err}
 		}
-		return &Response{res, resUri, &Body{reader: res.Body, compressedReader: compressedReader}, res}, nil
+		return &Response{res, resUri, &Body{reader: res.Body, compressedReader: compressedReader}}, nil
 	} else {
-		return &Response{res, resUri, &Body{reader: res.Body}, res}, nil
+		return &Response{res, resUri, &Body{reader: res.Body}}, nil
 	}
 }
 

--- a/goreq.go
+++ b/goreq.go
@@ -248,8 +248,6 @@ func (r Request) WithCookie(c *http.Cookie) Request {
 }
 
 func (r Request) Do() (*Response, error) {
-	var req *http.Request
-	var er error
 	var transport = defaultTransport
 	var client = defaultClient
 	var resUri string
@@ -309,65 +307,11 @@ func (r Request) Do() (*Response, error) {
 		transport.TLSClientConfig.InsecureSkipVerify = false
 	}
 
-	b, e := prepareRequestBody(r.Body)
-	if e != nil {
-		// there was a problem marshaling the body
-		return nil, &Error{Err: e}
-	}
+	req, err := r.NewRequest()
 
-	if r.QueryString != nil {
-		param, e := paramParse(r.QueryString)
-		if e != nil {
-			return nil, &Error{Err: e}
-		}
-		r.Uri = r.Uri + "?" + param
-	}
-
-	var bodyReader io.Reader
-	if b != nil && r.Compression != nil {
-		buffer := bytes.NewBuffer([]byte{})
-		readBuffer := bufio.NewReader(b)
-		writer, err := r.Compression.writer(buffer)
-		if err != nil {
-			return nil, &Error{Err: err}
-		}
-		_, e = readBuffer.WriteTo(writer)
-		writer.Close()
-		if e != nil {
-			return nil, &Error{Err: e}
-		}
-		bodyReader = buffer
-	} else {
-		bodyReader = b
-	}
-	req, er = http.NewRequest(r.Method, r.Uri, bodyReader)
-
-	if er != nil {
+	if err != nil {
 		// we couldn't parse the URL.
-		return nil, &Error{Err: er}
-	}
-
-	// add headers to the request
-	req.Host = r.Host
-
-	r.addHeaders(req.Header)
-	if r.Compression != nil {
-		req.Header.Add("Content-Encoding", r.Compression.ContentEncoding)
-		req.Header.Add("Accept-Encoding", r.Compression.ContentEncoding)
-	}
-	if r.headers != nil {
-		for _, header := range r.headers {
-			req.Header.Add(header.name, header.value)
-		}
-	}
-
-	//use basic auth if required
-	if r.BasicAuthUsername != "" {
-		req.SetBasicAuth(r.BasicAuthUsername, r.BasicAuthPassword)
-	}
-
-	for _, c := range r.cookies {
-		req.AddCookie(c)
+		return nil, &Error{Err: err}
 	}
 
 	timeout := false
@@ -435,6 +379,69 @@ func (r Request) addHeaders(headersMap http.Header) {
 	}
 	headersMap.Add("Accept", r.Accept)
 	headersMap.Add("Content-Type", r.ContentType)
+}
+
+func (r Request) NewRequest() (*http.Request, error) {
+
+	b, e := prepareRequestBody(r.Body)
+	if e != nil {
+		// there was a problem marshaling the body
+		return nil, &Error{Err: e}
+	}
+
+	if r.QueryString != nil {
+		param, e := paramParse(r.QueryString)
+		if e != nil {
+			return nil, &Error{Err: e}
+		}
+		r.Uri = r.Uri + "?" + param
+	}
+
+	var bodyReader io.Reader
+	if b != nil && r.Compression != nil {
+		buffer := bytes.NewBuffer([]byte{})
+		readBuffer := bufio.NewReader(b)
+		writer, err := r.Compression.writer(buffer)
+		if err != nil {
+			return nil, &Error{Err: err}
+		}
+		_, e = readBuffer.WriteTo(writer)
+		writer.Close()
+		if e != nil {
+			return nil, &Error{Err: e}
+		}
+		bodyReader = buffer
+	} else {
+		bodyReader = b
+	}
+
+	req, err := http.NewRequest(r.Method, r.Uri, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	// add headers to the request
+	req.Host = r.Host
+
+	r.addHeaders(req.Header)
+	if r.Compression != nil {
+		req.Header.Add("Content-Encoding", r.Compression.ContentEncoding)
+		req.Header.Add("Accept-Encoding", r.Compression.ContentEncoding)
+	}
+	if r.headers != nil {
+		for _, header := range r.headers {
+			req.Header.Add(header.name, header.value)
+		}
+	}
+
+	//use basic auth if required
+	if r.BasicAuthUsername != "" {
+		req.SetBasicAuth(r.BasicAuthUsername, r.BasicAuthPassword)
+	}
+
+	for _, c := range r.cookies {
+		req.AddCookie(c)
+	}
+	return req, nil
 }
 
 // Return value if nonempty, def otherwise.

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -705,7 +705,7 @@ func TestRequest(t *testing.T) {
 				g.It("Should return the original request response", func() {
 					res, _ := Request{Method: "POST", Uri: ts.URL, Body: `{"foo": "bar"}`}.Do()
 
-					Expect(res.Raw).ShouldNot(BeNil())
+					Expect(res.Response).ShouldNot(BeNil())
 				})
 			})
 			g.Describe("Redirects", func() {

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -692,6 +692,16 @@ func TestRequest(t *testing.T) {
 					Expect(string(body)).Should(Equal("foo bar"))
 				})
 
+				g.It("Should handle parsing JSON", func() {
+					res, _ := Request{Method: "POST", Uri: ts.URL, Body: `{"foo": "bar"}`}.Do()
+
+					var foobar map[string]string
+
+					res.Body.FromJsonTo(&foobar)
+
+					Expect(foobar).Should(Equal(map[string]string{"foo": "bar"}))
+				})
+
 				g.It("Should return the original request response", func() {
 					res, _ := Request{Method: "POST", Uri: ts.URL, Body: `{"foo": "bar"}`}.Do()
 

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -692,14 +692,10 @@ func TestRequest(t *testing.T) {
 					Expect(string(body)).Should(Equal("foo bar"))
 				})
 
-				g.It("Should handle parsing JSON", func() {
+				g.It("Should return the original request response", func() {
 					res, _ := Request{Method: "POST", Uri: ts.URL, Body: `{"foo": "bar"}`}.Do()
 
-					var foobar map[string]string
-
-					res.Body.FromJsonTo(&foobar)
-
-					Expect(foobar).Should(Equal(map[string]string{"foo": "bar"}))
+					Expect(res.Raw).ShouldNot(BeNil())
 				})
 			})
 			g.Describe("Redirects", func() {

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -914,6 +914,16 @@ func TestRequest(t *testing.T) {
 				Expect(defaultTransport.TLSClientConfig.InsecureSkipVerify).Should(Equal(true))
 				Expect(res.StatusCode).Should(Equal(200))
 			})
+
+			g.It("GetRequest should return the underlying httpRequest ", func() {
+				req := Request{
+					Host: "foobar.com",
+				}
+
+				request, _ := req.NewRequest()
+				Expect(request).ShouldNot(BeNil())
+				Expect(request.Host).Should(Equal(req.Host))
+			})
 		})
 
 		g.Describe("Errors", func() {


### PR DESCRIPTION
are already present in the original response structure
Add Raw field to Response structure so functions from other packages
that require the *http.Response (such as httputil can use them)