### PR TITLE
Remove useless flate base decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,22 +265,13 @@ res, err := goreq.Request{
     Compression: goreq.Gzip(),
 }.Do()
 ```
-#####Using deflate compression:
+#####Using deflate/zlib compression:
 ```go
 res, err := goreq.Request{
     Method: "POST",
     Uri: "http://www.google.com",
     Body: item,
     Compression: goreq.Deflate(),
-}.Do()
-```
-#####Using zlib compression:
-```go
-res, err := goreq.Request{
-    Method: "POST",
-    Uri: "http://www.google.com",
-    Body: item,
-    Compression: goreq.Zlib(),
 }.Do()
 ```
 #####Using compressed responses:

--- a/goreq.go
+++ b/goreq.go
@@ -128,6 +128,10 @@ func Deflate() *compression {
 	return &compression{writer: writer, reader: reader, ContentEncoding: "deflate"}
 }
 
+func Zlib() *compression {
+	return Deflate()
+}
+
 func paramParse(query interface{}) (string, error) {
 	switch query.(type) {
 	case url.Values:

--- a/goreq.go
+++ b/goreq.go
@@ -3,7 +3,6 @@ package goreq
 import (
 	"bufio"
 	"bytes"
-	"compress/flate"
 	"compress/gzip"
 	"compress/zlib"
 	"crypto/tls"
@@ -120,16 +119,6 @@ func Gzip() *compression {
 }
 
 func Deflate() *compression {
-	reader := func(buffer io.Reader) (io.ReadCloser, error) {
-		return flate.NewReader(buffer), nil
-	}
-	writer := func(buffer io.Writer) (io.WriteCloser, error) {
-		return flate.NewWriter(buffer, -1)
-	}
-	return &compression{writer: writer, reader: reader, ContentEncoding: "deflate"}
-}
-
-func Zlib() *compression {
 	reader := func(buffer io.Reader) (io.ReadCloser, error) {
 		return zlib.NewReader(buffer)
 	}

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -1,7 +1,6 @@
 package goreq
 
 import (
-	"compress/flate"
 	"compress/gzip"
 	"compress/zlib"
 	"encoding/base64"
@@ -118,17 +117,6 @@ func TestRequest(t *testing.T) {
 					if r.Method == "GET" && r.URL.Path == "/compressed_deflate" {
 						defer r.Body.Close()
 						b := "{\"foo\":\"bar\",\"fuu\":\"baz\"}"
-						gw, _ := flate.NewWriter(w, -1)
-						defer gw.Close()
-						if strings.Contains(r.Header.Get("Content-Encoding"), "deflate") {
-							w.Header().Add("Content-Encoding", "deflate")
-						}
-						w.WriteHeader(200)
-						gw.Write([]byte(b))
-					}
-					if r.Method == "GET" && r.URL.Path == "/compressed_zlib" {
-						defer r.Body.Close()
-						b := "{\"foo\":\"bar\",\"fuu\":\"baz\"}"
 						gw := zlib.NewWriter(w)
 						defer gw.Close()
 						if strings.Contains(r.Header.Get("Content-Encoding"), "deflate") {
@@ -148,14 +136,6 @@ func TestRequest(t *testing.T) {
 					if r.Method == "GET" && r.URL.Path == "/compressed_deflate_and_return_compressed_without_header" {
 						defer r.Body.Close()
 						b := "{\"foo\":\"bar\",\"fuu\":\"baz\"}"
-						gw, _ := flate.NewWriter(w, -1)
-						defer gw.Close()
-						w.WriteHeader(200)
-						gw.Write([]byte(b))
-					}
-					if r.Method == "GET" && r.URL.Path == "/compressed_zlib_and_return_compressed_without_header" {
-						defer r.Body.Close()
-						b := "{\"foo\":\"bar\",\"fuu\":\"baz\"}"
 						gw := zlib.NewWriter(w)
 						defer gw.Close()
 						w.WriteHeader(200)
@@ -171,14 +151,6 @@ func TestRequest(t *testing.T) {
 					}
 					if r.Method == "POST" && r.URL.Path == "/compressed_deflate" && r.Header.Get("Content-Encoding") == "deflate" {
 						defer r.Body.Close()
-						gr := flate.NewReader(r.Body)
-						defer gr.Close()
-						b, _ := ioutil.ReadAll(gr)
-						w.WriteHeader(201)
-						w.Write(b)
-					}
-					if r.Method == "POST" && r.URL.Path == "/compressed_zlib" && r.Header.Get("Content-Encoding") == "deflate" {
-						defer r.Body.Close()
 						gr, _ := zlib.NewReader(r.Body)
 						defer gr.Close()
 						b, _ := ioutil.ReadAll(gr)
@@ -192,17 +164,6 @@ func TestRequest(t *testing.T) {
 						io.Copy(w, r.Body)
 					}
 					if r.Method == "POST" && r.URL.Path == "/compressed_deflate_and_return_compressed" {
-						defer r.Body.Close()
-						w.Header().Add("Content-Encoding", "deflate")
-						w.WriteHeader(201)
-						io.Copy(w, r.Body)
-					}
-					if r.Method == "POST" && r.URL.Path == "/compressed_zlib_and_return_compressed_without_header" {
-						defer r.Body.Close()
-						w.WriteHeader(201)
-						io.Copy(w, r.Body)
-					}
-					if r.Method == "POST" && r.URL.Path == "/compressed_zlib_and_return_compressed" {
 						defer r.Body.Close()
 						w.Header().Add("Content-Encoding", "deflate")
 						w.WriteHeader(201)
@@ -365,20 +326,6 @@ func TestRequest(t *testing.T) {
 
 				g.It("Should not return a delfate reader if Content-Encoding is not 'deflate'", func() {
 					res, err := Request{Uri: ts.URL + "/compressed_deflate_and_return_compressed_without_header", Compression: Deflate()}.Do()
-					b, _ := ioutil.ReadAll(res.Body)
-					Expect(err).Should(BeNil())
-					Expect(string(b)).ShouldNot(Equal("{\"foo\":\"bar\",\"fuu\":\"baz\"}"))
-				})
-
-				g.It("Should return a zlib reader if Content-Encoding is 'deflate'", func() {
-					res, err := Request{Uri: ts.URL + "/compressed_zlib", Compression: Zlib()}.Do()
-					b, _ := ioutil.ReadAll(res.Body)
-					Expect(err).Should(BeNil())
-					Expect(string(b)).Should(Equal("{\"foo\":\"bar\",\"fuu\":\"baz\"}"))
-				})
-
-				g.It("Should not return a zlib reader if Content-Encoding is not 'deflate'", func() {
-					res, err := Request{Uri: ts.URL + "/compressed_zlib_and_return_compressed_without_header", Compression: Zlib()}.Do()
 					b, _ := ioutil.ReadAll(res.Body)
 					Expect(err).Should(BeNil())
 					Expect(string(b)).ShouldNot(Equal("{\"foo\":\"bar\",\"fuu\":\"baz\"}"))
@@ -554,16 +501,6 @@ func TestRequest(t *testing.T) {
 					Expect(res.StatusCode).Should(Equal(201))
 				})
 
-				g.It("Should send body as zlib if compressed", func() {
-					obj := map[string]string{"foo": "bar"}
-					res, err := Request{Method: "POST", Uri: ts.URL + "/compressed_zlib", Body: obj, Compression: Zlib()}.Do()
-
-					Expect(err).Should(BeNil())
-					str, _ := res.Body.ToString()
-					Expect(str).Should(Equal(`{"foo":"bar"}`))
-					Expect(res.StatusCode).Should(Equal(201))
-				})
-
 				g.It("Should send body as gzip if compressed and parse return body", func() {
 					obj := map[string]string{"foo": "bar"}
 					res, err := Request{Method: "POST", Uri: ts.URL + "/compressed_and_return_compressed", Body: obj, Compression: Gzip()}.Do()
@@ -584,16 +521,6 @@ func TestRequest(t *testing.T) {
 					Expect(res.StatusCode).Should(Equal(201))
 				})
 
-				g.It("Should send body as zlib if compressed and parse return body", func() {
-					obj := map[string]string{"foo": "bar"}
-					res, err := Request{Method: "POST", Uri: ts.URL + "/compressed_zlib_and_return_compressed", Body: obj, Compression: Zlib()}.Do()
-
-					Expect(err).Should(BeNil())
-					b, _ := ioutil.ReadAll(res.Body)
-					Expect(string(b)).Should(Equal(`{"foo":"bar"}`))
-					Expect(res.StatusCode).Should(Equal(201))
-				})
-
 				g.It("Should send body as gzip if compressed and not parse return body if header not set ", func() {
 					obj := map[string]string{"foo": "bar"}
 					res, err := Request{Method: "POST", Uri: ts.URL + "/compressed_and_return_compressed_without_header", Body: obj, Compression: Gzip()}.Do()
@@ -607,16 +534,6 @@ func TestRequest(t *testing.T) {
 				g.It("Should send body as deflate if compressed and not parse return body if header not set ", func() {
 					obj := map[string]string{"foo": "bar"}
 					res, err := Request{Method: "POST", Uri: ts.URL + "/compressed_deflate_and_return_compressed_without_header", Body: obj, Compression: Deflate()}.Do()
-
-					Expect(err).Should(BeNil())
-					b, _ := ioutil.ReadAll(res.Body)
-					Expect(string(b)).ShouldNot(Equal(`{"foo":"bar"}`))
-					Expect(res.StatusCode).Should(Equal(201))
-				})
-
-				g.It("Should send body as zlib if compressed and not parse return body if header not set ", func() {
-					obj := map[string]string{"foo": "bar"}
-					res, err := Request{Method: "POST", Uri: ts.URL + "/compressed_zlib_and_return_compressed_without_header", Body: obj, Compression: Zlib()}.Do()
 
 					Expect(err).Should(BeNil())
 					b, _ := ioutil.ReadAll(res.Body)

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -331,6 +331,20 @@ func TestRequest(t *testing.T) {
 					Expect(string(b)).ShouldNot(Equal("{\"foo\":\"bar\",\"fuu\":\"baz\"}"))
 				})
 
+				g.It("Should return a deflate reader when using zlib if Content-Encoding is 'deflate'", func() {
+					res, err := Request{Uri: ts.URL + "/compressed_deflate", Compression: Zlib()}.Do()
+					b, _ := ioutil.ReadAll(res.Body)
+					Expect(err).Should(BeNil())
+					Expect(string(b)).Should(Equal("{\"foo\":\"bar\",\"fuu\":\"baz\"}"))
+				})
+
+				g.It("Should not return a delfate reader when using zlib if Content-Encoding is not 'deflate'", func() {
+					res, err := Request{Uri: ts.URL + "/compressed_deflate_and_return_compressed_without_header", Compression: Zlib()}.Do()
+					b, _ := ioutil.ReadAll(res.Body)
+					Expect(err).Should(BeNil())
+					Expect(string(b)).ShouldNot(Equal("{\"foo\":\"bar\",\"fuu\":\"baz\"}"))
+				})
+
 				g.It("Should send cookies from the cookiejar", func() {
 					uri, err := url.Parse(ts.URL + "/getcookies")
 					Expect(err).Should(BeNil())
@@ -501,6 +515,16 @@ func TestRequest(t *testing.T) {
 					Expect(res.StatusCode).Should(Equal(201))
 				})
 
+				g.It("Should send body as deflate using zlib if compressed", func() {
+					obj := map[string]string{"foo": "bar"}
+					res, err := Request{Method: "POST", Uri: ts.URL + "/compressed_deflate", Body: obj, Compression: Zlib()}.Do()
+
+					Expect(err).Should(BeNil())
+					str, _ := res.Body.ToString()
+					Expect(str).Should(Equal(`{"foo":"bar"}`))
+					Expect(res.StatusCode).Should(Equal(201))
+				})
+
 				g.It("Should send body as gzip if compressed and parse return body", func() {
 					obj := map[string]string{"foo": "bar"}
 					res, err := Request{Method: "POST", Uri: ts.URL + "/compressed_and_return_compressed", Body: obj, Compression: Gzip()}.Do()
@@ -521,6 +545,16 @@ func TestRequest(t *testing.T) {
 					Expect(res.StatusCode).Should(Equal(201))
 				})
 
+				g.It("Should send body as deflate using zlib if compressed and parse return body", func() {
+					obj := map[string]string{"foo": "bar"}
+					res, err := Request{Method: "POST", Uri: ts.URL + "/compressed_deflate_and_return_compressed", Body: obj, Compression: Zlib()}.Do()
+
+					Expect(err).Should(BeNil())
+					b, _ := ioutil.ReadAll(res.Body)
+					Expect(string(b)).Should(Equal(`{"foo":"bar"}`))
+					Expect(res.StatusCode).Should(Equal(201))
+				})
+
 				g.It("Should send body as gzip if compressed and not parse return body if header not set ", func() {
 					obj := map[string]string{"foo": "bar"}
 					res, err := Request{Method: "POST", Uri: ts.URL + "/compressed_and_return_compressed_without_header", Body: obj, Compression: Gzip()}.Do()
@@ -534,6 +568,16 @@ func TestRequest(t *testing.T) {
 				g.It("Should send body as deflate if compressed and not parse return body if header not set ", func() {
 					obj := map[string]string{"foo": "bar"}
 					res, err := Request{Method: "POST", Uri: ts.URL + "/compressed_deflate_and_return_compressed_without_header", Body: obj, Compression: Deflate()}.Do()
+
+					Expect(err).Should(BeNil())
+					b, _ := ioutil.ReadAll(res.Body)
+					Expect(string(b)).ShouldNot(Equal(`{"foo":"bar"}`))
+					Expect(res.StatusCode).Should(Equal(201))
+				})
+
+				g.It("Should send body as deflate using zlib if compressed and not parse return body if header not set ", func() {
+					obj := map[string]string{"foo": "bar"}
+					res, err := Request{Method: "POST", Uri: ts.URL + "/compressed_deflate_and_return_compressed_without_header", Body: obj, Compression: Zlib()}.Do()
 
 					Expect(err).Should(BeNil())
 					b, _ := ioutil.ReadAll(res.Body)


### PR DESCRIPTION
As mentioned in #87 goreq has Deflate and Zlib decoders but it turns out http defalte is actually Zlib, so old Deflate decoder is now replaced by Zlib

Cheers!