### PR TITLE
Define the DefaultTransport as a RoundTripper

### DIFF
--- a/goreq_test.go
+++ b/goreq_test.go
@@ -872,7 +872,7 @@ func TestRequest(t *testing.T) {
 				}
 				res, _ := req.Do()
 
-				Expect(DefaultTransport.TLSClientConfig.InsecureSkipVerify).Should(Equal(true))
+				Expect(DefaultTransport.(*http.Transport).TLSClientConfig.InsecureSkipVerify).Should(Equal(true))
 				Expect(res.StatusCode).Should(Equal(200))
 			})
 


### PR DESCRIPTION
I'd like to use a http2 transport for goreq, however the current library assumes the Transports will be a `http.Transport` instead of `http.RoundTripper` (like the docs). With this PR, you can make http2 requests like so with goreq - with the second request speaking http2.

```go
package main

import (
	"fmt"
	"github.com/bradfitz/http2"
	"github.com/franela/goreq"
	"net/http"
)

func main() {
	res, _ := goreq.Request{Uri: "https://http2.golang.org/"}.Do()
	s, _ := res.Body.ToString()
	fmt.Printf("%s", s)
	fmt.Println("\n------")
	goreq.DefaultTransport = &http2.Transport{InsecureTLSDial: true}
	goreq.DefaultClient = &http.Client{Transport: goreq.DefaultTransport}
	res, _ = goreq.Request{Uri: "https://http2.golang.org/"}.Do()
	s, _ = res.Body.ToString()
	fmt.Printf("%s", s)
}
```