### PR TITLE
avoid nil pointer exception in case of nil http response

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -364,7 +364,11 @@ func (r Request) Do() (*Response, error) {
 		var response *Response
 		//If redirect fails we still want to return response data
 		if redirectFailed {
-			response = &Response{res, resUri, &Body{reader: res.Body}, req}
+			if res != nil {
+				response = &Response{res, resUri, &Body{reader: res.Body}, req}
+			} else {
+				response = &Response{res, resUri, nil, req}
+			}
 		}
 
 		//If redirect fails and we haven't set a redirect count we shouldn't return an error


### PR DESCRIPTION
sometimes the standard http client.Do functionality returns err and nil as http response

This small condition insures the code does not panic when the Body property of a nil res is being accessed