### PR TITLE
Allow to set case-sensitive headers.

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -450,7 +450,7 @@ func (r Request) NewRequest() (*http.Request, error) {
 	}
 	if r.headers != nil {
 		for _, header := range r.headers {
-			req.Header.Add(header.name, header.value)
+			req.Header[header.name] = []string{header.value}
 		}
 	}
 


### PR DESCRIPTION
Even though `Request.Header.Add` canonizes headers, some web servers
don't standardize them and they're passed to the apps in
a case-sensitive manner.

This PR allows users to set case-sensitive headers to the request

@sschepens @j16sdiz what do you think?