### PR TITLE
Added feature to squash embed struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Simple and sane HTTP request library for Go language.
 - [What can I do with it?](#user-content-what-can-i-do-with-it)
   - [Making requests with different methods](#user-content-making-requests-with-different-methods)
   - [GET](#user-content-get)
+    - [Tags](#user-content-tags)
   - [POST](#user-content-post)
     - [Sending payloads in the Body](#user-content-sending-payloads-in-the-body)
-  - [Tags](#user-content-tags)
   - [Specifiying request headers](#user-content-specifiying-request-headers)
   - [Sending Cookies](#cookie-support)
   - [Setting timeouts](#user-content-setting-timeouts)
@@ -121,34 +121,6 @@ res, err := goreq.Request{
 
 The sample above will send `http://localhost:3000/?limit=3&field=somefield&field=someotherfield`
 
-
-
-#### POST
-
-```go
-res, err := goreq.Request{ Method: "POST", Uri: "http://www.google.com" }.Do()
-```
-
-## Sending payloads in the Body
-
-You can send ```string```, ```Reader``` or ```interface{}``` in the body. The first two will be sent as text. The last one will be marshalled to JSON, if possible.
-
-```go
-type Item struct {
-    Id int
-    Name string
-}
-
-item := Item{ Id: 1111, Name: "foobar" }
-
-res, err := goreq.Request{
-    Method: "POST",
-    Uri: "http://www.google.com",
-    Body: item,
-}.Do()
-```
-
-
 ### Tags
 
 Struct field `url` tag is mainly used as the request parameter name.
@@ -213,6 +185,32 @@ goreq.Request{
 	QueryString: samurai,
 }.Do()
 // =>  `http://localhost/?first_name=&last_name=yagyu&country=Japan&city=Tokyo`
+```
+
+
+#### POST
+
+```go
+res, err := goreq.Request{ Method: "POST", Uri: "http://www.google.com" }.Do()
+```
+
+## Sending payloads in the Body
+
+You can send ```string```, ```Reader``` or ```interface{}``` in the body. The first two will be sent as text. The last one will be marshalled to JSON, if possible.
+
+```go
+type Item struct {
+    Id int
+    Name string
+}
+
+item := Item{ Id: 1111, Name: "foobar" }
+
+res, err := goreq.Request{
+    Method: "POST",
+    Uri: "http://www.google.com",
+    Body: item,
+}.Do()
 ```
 
 ## Specifiying request headers

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -1092,7 +1092,7 @@ func Test_paramParse(t *testing.T) {
 	type EmbedForm struct {
 		AnnotedForm `url:",squash"`
 		Form        `url:",squash"`
-		Corge       string `url"corge`
+		Corge       string `url:"corge"`
 	}
 
 	g := Goblin(t)

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -1089,10 +1089,17 @@ func Test_paramParse(t *testing.T) {
 		Qux  string `url:"-"`
 	}
 
+	type EmbedForm struct {
+		AnnotedForm `url:",squash"`
+		Form        `url:",squash"`
+		Corge       string `url"corge`
+	}
+
 	g := Goblin(t)
 	RegisterFailHandler(func(m string, _ ...int) { g.Fail(m) })
 	var form = Form{}
 	var aform = AnnotedForm{}
+	var eform = EmbedForm{}
 	var values = url.Values{}
 	const result = "a=1&b=2"
 	g.Describe("QueryString ParamParse", func() {
@@ -1103,6 +1110,9 @@ func Test_paramParse(t *testing.T) {
 			aform.Foo = "xyz"
 			aform.Norf = "abc"
 			aform.Qux = "def"
+			eform.Form = form
+			eform.AnnotedForm = aform
+			eform.Corge = "xxx"
 			values.Add("a", "1")
 			values.Add("b", "2")
 		})
@@ -1128,6 +1138,11 @@ func Test_paramParse(t *testing.T) {
 			Expect(err).Should(BeNil())
 			Expect(str).Should(Equal(result))
 		})
+		g.It("Should accept embedded struct", func() {
+			str, err := paramParse(eform)
+			Expect(err).Should(BeNil())
+			Expect(str).Should(Equal("a=1&b=2&corge=xxx&foo_bar=xyz&norf=abc"))
+		})
 		g.It("Should accept interface{} which forcely converted by struct", func() {
 			str, err := paramParse(interface{}(&form))
 			Expect(err).Should(BeNil())
@@ -1140,7 +1155,7 @@ func Test_paramParse(t *testing.T) {
 			Expect(str).Should(Equal(result))
 		})
 		g.It("Should accept &url.Values", func() {
-			str, err := paramParse(values)
+			str, err := paramParse(&values)
 			Expect(err).Should(BeNil())
 			Expect(str).Should(Equal(result))
 		})


### PR DESCRIPTION
This PR added feature for adding embedded struct to request parameter.
use `squash` in field tag (like `omitempty`), the struct is searched recursively and add values to request parameter.

this concept is the squash tag in [mitchellh/mapstructure](https://github.com/mitchellh/mapstructure/blob/master/mapstructure.go#L622).