### PR TITLE
fix Insecure option

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -325,10 +325,12 @@ func (r Request) Do() (*Response, error) {
 	if transport, ok := transport.(*http.Transport); ok {
 		if r.Insecure {
 			transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+			client.Transport = transport
 		} else if transport.TLSClientConfig != nil {
 			// the default TLS client (when transport.TLSClientConfig==nil) is
 			// already set to verify, so do nothing in that case
 			transport.TLSClientConfig.InsecureSkipVerify = false
+			client.Transport = transport
 		}
 	}
 


### PR DESCRIPTION
I'm not sure what happened here exactly but I think in a refactor it made it so the insecure flag quit working. I'm not 100% if this is the right fix, it's possible the transport isn't being used at all anymore