### PR TITLE
Fixed request timeout when proxy is set

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -59,13 +59,13 @@ type Response struct {
 }
 
 func (r Response) CancelRequest() {
-	cancelRequest(r.req)
+	cancelRequest(DefaultTransport, r.req)
 
 }
 
-func cancelRequest(r *http.Request) {
-	if transport, ok := DefaultTransport.(transportRequestCanceler); ok {
-		transport.CancelRequest(r)
+func cancelRequest(transport interface{}, r *http.Request) {
+	if tp, ok := transport.(transportRequestCanceler); ok {
+		tp.CancelRequest(r)
 	}
 }
 
@@ -348,7 +348,7 @@ func (r Request) Do() (*Response, error) {
 	var timer *time.Timer
 	if r.Timeout > 0 {
 		timer = time.AfterFunc(r.Timeout, func() {
-			cancelRequest(req)
+			cancelRequest(transport, req)
 			timeout = true
 		})
 	}

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -809,6 +809,26 @@ func TestRequest(t *testing.T) {
 					Expect(res).Should(BeNil())
 					Expect(err.(*Error).Timeout()).Should(BeTrue())
 				})
+				g.It("Should request timeout after a custom amount of time even with proxy", func() {
+					proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						time.Sleep(2000 * time.Millisecond)
+						w.WriteHeader(200)
+					}))
+					SetConnectTimeout(1000 * time.Millisecond)
+					start := time.Now()
+					request := Request{
+						Uri:     ts.URL,
+						Proxy:   proxy.URL,
+						Timeout: 500 * time.Millisecond,
+					}
+					res, err := request.Do()
+					elapsed := time.Since(start)
+
+					Expect(elapsed).Should(BeNumerically("<", 550*time.Millisecond))
+					Expect(elapsed).Should(BeNumerically(">=", 500*time.Millisecond))
+					Expect(res).Should(BeNil())
+					Expect(err.(*Error).Timeout()).Should(BeTrue())
+				})
 			})
 		})
 


### PR DESCRIPTION
As timeout is not working when proxy is set, This PR fixed it.

- using not `DefaultTransport` but each `transport` in `cancelRequest()` 