### PR TITLE
Add custom body to Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Simple and sane HTTP request library for Go language.
     - [Tags](#user-content-tags)
   - [POST](#user-content-post)
     - [Sending payloads in the Body](#user-content-sending-payloads-in-the-body)
+    - [Sending custom Body](#user-content-sending-custom-body)
   - [Specifiying request headers](#user-content-specifiying-request-headers)
   - [Sending Cookies](#cookie-support)
   - [Setting timeouts](#user-content-setting-timeouts)
@@ -210,6 +211,25 @@ res, err := goreq.Request{
     Method: "POST",
     Uri: "http://www.google.com",
     Body: item,
+}.Do()
+```
+
+## Sending custom Body
+
+You can send custom params in the body using ```BodyReader``` field.
+
+```go
+params := url.Values{}
+params.Add("user", "Jhon")
+params.Add("password", "myPass")
+params.Add("product", 123)
+params.Add("format", "xml")
+
+res, err := goreq.Request{
+    Method: "POST",
+    Uri: "http://www.google.com",
+    ContentType: "application/x-www-form-urlencoded",
+    BodyReader: strings.NewReader(params.Encode()),
 }.Do()
 ```
 

--- a/goreq.go
+++ b/goreq.go
@@ -30,6 +30,7 @@ type Request struct {
 	Method            string
 	Uri               string
 	Body              interface{}
+	BodyReader        io.Reader
 	QueryString       interface{}
 	Timeout           time.Duration
 	ContentType       string
@@ -436,7 +437,9 @@ func (r Request) NewRequest() (*http.Request, error) {
 	}
 
 	var bodyReader io.Reader
-	if b != nil && r.Compression != nil {
+	if r.BodyReader != nil {
+		bodyReader = r.BodyReader
+	} else if b != nil && r.Compression != nil {
 		buffer := bytes.NewBuffer([]byte{})
 		readBuffer := bufio.NewReader(b)
 		writer, err := r.Compression.writer(buffer)


### PR DESCRIPTION
When I need to send my post in different format (xml instead) always sent as json. Now you can send a custom body with a BodyReader field as io.Reader type.
Ej.:

```go
res, err := goreq.Request{
    Method: "POST",
    Uri: "http://www.google.com",
    ContentType: "application/x-www-form-urlencoded",
    BodyReader: strings.NewReader(params.Encode()),
}.Do()
```