### PR TITLE
Transparently compress and streaming support v2

### DIFF
--- a/compress_reader.go
+++ b/compress_reader.go
@@ -1,0 +1,40 @@
+package goreq
+
+import "io"
+
+type compressReader struct {
+	source     io.Reader
+	compressor io.WriteCloser
+	dest       io.Reader
+	eof        bool
+}
+
+func newCompressReader(source io.Reader, compressor io.WriteCloser, dest io.Reader) *compressReader {
+	return &compressReader{source: source, compressor: compressor, dest: dest}
+}
+
+func (cr *compressReader) Read(p []byte) (n int, err error) {
+	buf := make([]byte, cap(p), len(p))
+	n, err = cr.source.Read(buf)
+	if n > 0 {
+		i, e := cr.compressor.Write(buf[:n])
+		if e != nil {
+			return i, e
+		}
+	}
+	if err == io.EOF && !cr.eof {
+		cr.eof = true
+		cr.compressor.Close()
+	}
+	return cr.dest.Read(p)
+}
+
+func (cr *compressReader) Close() error {
+	if v, ok := cr.source.(io.ReadCloser); !ok {
+		if v != nil {
+			v.Close()
+		}
+	}
+	cr.compressor.Close()
+	return nil
+}

--- a/compress_reader.go
+++ b/compress_reader.go
@@ -14,7 +14,7 @@ func newCompressReader(source io.Reader, compressor io.WriteCloser, dest io.Read
 }
 
 func (cr *compressReader) Read(p []byte) (n int, err error) {
-	buf := make([]byte, cap(p), len(p))
+	buf := make([]byte, len(p), cap(p))
 	n, err = cr.source.Read(buf)
 	if n > 0 {
 		i, e := cr.compressor.Write(buf[:n])

--- a/goreq.go
+++ b/goreq.go
@@ -1,7 +1,6 @@
 package goreq
 
 import (
-	"bufio"
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
@@ -438,17 +437,12 @@ func (r Request) NewRequest() (*http.Request, error) {
 	var bodyReader io.Reader
 	if b != nil && r.Compression != nil {
 		buffer := bytes.NewBuffer([]byte{})
-		readBuffer := bufio.NewReader(b)
 		writer, err := r.Compression.writer(buffer)
 		if err != nil {
 			return nil, &Error{Err: err}
 		}
-		_, e = readBuffer.WriteTo(writer)
-		writer.Close()
-		if e != nil {
-			return nil, &Error{Err: e}
-		}
-		bodyReader = buffer
+		cr := newCompressReader(b, writer, buffer)
+		bodyReader = cr
 	} else {
 		bodyReader = b
 	}

--- a/goreq.go
+++ b/goreq.go
@@ -436,12 +436,10 @@ func (r Request) NewRequest() (*http.Request, error) {
 
 	var bodyReader io.Reader
 	if b != nil && r.Compression != nil {
-		buffer := bytes.NewBuffer([]byte{})
-		writer, err := r.Compression.writer(buffer)
+		cr, err := newCompressReader(b, r.Compression.writer)
 		if err != nil {
 			return nil, &Error{Err: err}
 		}
-		cr := newCompressReader(b, writer, buffer)
 		bodyReader = cr
 	} else {
 		bodyReader = b


### PR DESCRIPTION
Based on the work and needs of @jetsanix on #128 
This creates a struct that receives a source `io.Reader` and a compression generator function.
This struct implements `io.Reader`, it reads from source and writes to the writer generated by the compression function and then returns the compressed data.

This should not break existing behavior, but should add support for compressing streams on the fly. All tests pass.

@marcosnils, @jetsanix what do you think?