### PR TITLE
Add parameter of ProxyConnectHeader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
- - 1.5.3
+ - 1.9.2
  - tip
 notifications:
   email:

--- a/goreq.go
+++ b/goreq.go
@@ -25,28 +25,28 @@ type itimeout interface {
 	Timeout() bool
 }
 type Request struct {
-	headers           []headerTuple
-	cookies           []*http.Cookie
-	Method            string
-	Uri               string
-	Body              interface{}
-	QueryString       interface{}
-	Timeout           time.Duration
-	ContentType       string
-	Accept            string
-	Host              string
-	UserAgent         string
-	Insecure          bool
-	MaxRedirects      int
-	RedirectHeaders   bool
-	Proxy             string
-	proxyHeaders      []headerTuple
-	Compression       *compression
-	BasicAuthUsername string
-	BasicAuthPassword string
-	CookieJar         http.CookieJar
-	ShowDebug         bool
-	OnBeforeRequest   func(goreq *Request, httpreq *http.Request)
+	headers             []headerTuple
+	cookies             []*http.Cookie
+	Method              string
+	Uri                 string
+	Body                interface{}
+	QueryString         interface{}
+	Timeout             time.Duration
+	ContentType         string
+	Accept              string
+	Host                string
+	UserAgent           string
+	Insecure            bool
+	MaxRedirects        int
+	RedirectHeaders     bool
+	Proxy               string
+	proxyConnectHeaders []headerTuple
+	Compression         *compression
+	BasicAuthUsername   string
+	BasicAuthPassword   string
+	CookieJar           http.CookieJar
+	ShowDebug           bool
+	OnBeforeRequest     func(goreq *Request, httpreq *http.Request)
 }
 
 type compression struct {
@@ -273,15 +273,15 @@ func (r Request) WithCookie(c *http.Cookie) Request {
 	return r
 }
 
-func (r *Request) AddProxyHeader(name string, value string) {
-	if r.proxyHeaders == nil {
-		r.proxyHeaders = []headerTuple{}
+func (r *Request) AddProxyConnectHeader(name string, value string) {
+	if r.proxyConnectHeaders == nil {
+		r.proxyConnectHeaders = []headerTuple{}
 	}
-	r.proxyHeaders = append(r.proxyHeaders, headerTuple{name: name, value: value})
+	r.proxyConnectHeaders = append(r.proxyConnectHeaders, headerTuple{name: name, value: value})
 }
 
-func (r Request) WithProxyHeader(name string, value string) Request {
-	r.AddProxyHeader(name, value)
+func (r Request) WithProxyConnectHeader(name string, value string) Request {
+	r.AddProxyConnectHeader(name, value)
 	return r
 }
 
@@ -310,8 +310,8 @@ func (r Request) Do() (*Response, error) {
 		}
 
 		proxyHeader := make(http.Header)
-		if r.proxyHeaders != nil {
-			for _, header := range r.proxyHeaders {
+		if r.proxyConnectHeaders != nil {
+			for _, header := range r.proxyConnectHeaders {
 				proxyHeader.Add(header.name, header.value)
 			}
 		}

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -1139,7 +1139,7 @@ func TestRequest(t *testing.T) {
 				res, err := Request{Uri: ts.URL,
 					Proxy:    proxy.URL,
 					Insecure: true,
-				}.WithProxyHeader("X-TEST-HEADER", "TEST").Do()
+				}.WithProxyConnectHeader("X-TEST-HEADER", "TEST").Do()
 				defer res.Body.Close()
 
 				var got *http.Request

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -1072,44 +1072,6 @@ func TestRequest(t *testing.T) {
 			createServer := func() {
 				proxy = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					proxyCh <- r
-					// Implement an entire CONNECT proxy
-					if r.Method == "CONNECT" {
-						// hijacker, ok := w.(http.Hijacker)
-						// if !ok {
-						// 	t.Errorf("hijack not allowed")
-						// 	return
-						// }
-						// clientConn, _, err := hijacker.Hijack()
-						// if err != nil {
-						// 	t.Errorf("hijacking failed")
-						// 	return
-						// }
-
-						// res := &http.Response{
-						// 	StatusCode: http.StatusOK,
-						// 	Proto:      "HTTP/1.1",
-						// 	ProtoMajor: 1,
-						// 	ProtoMinor: 1,
-						// 	Header:     r.Header,
-						// }
-
-						// targetConn, err := net.Dial("tcp", r.URL.Host)
-						// if err != nil {
-						// 	t.Errorf("net.Dial(%q) failed: %v", r.URL.Host, err)
-						// 	return
-						// }
-
-						// if err := res.Write(clientConn); err != nil {
-						// 	t.Errorf("Writing 200 OK failed: %v", err)
-						// 	return
-						// }
-
-						// go io.Copy(targetConn, clientConn)
-						// go func() {
-						// 	io.Copy(clientConn, targetConn)
-						// 	targetConn.Close()
-						// }()
-					}
 				}))
 			}
 

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -1061,6 +1062,98 @@ func TestRequest(t *testing.T) {
 				Expect(jar.Cookies(proxiedHost)).Should(HaveLen(1))
 				Expect(jar.Cookies(proxiedHost)[0].Name).Should(Equal("foo"))
 				Expect(jar.Cookies(proxiedHost)[0].Value).Should(Equal("bar"))
+			})
+
+		})
+
+		g.Describe("TLS Proxy", func() {
+			var ts *httptest.Server
+			var proxy *httptest.Server
+			proxyCh := make(chan *http.Request, 1)
+
+			createServer := func() {
+				ts = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Write([]byte("Hello"))
+					w.(http.Flusher).Flush()
+				}))
+
+				proxy = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					proxyCh <- r
+					// Implement an entire CONNECT proxy
+					if r.Method == "CONNECT" {
+						hijacker, ok := w.(http.Hijacker)
+						if !ok {
+							t.Errorf("hijack not allowed")
+							return
+						}
+						clientConn, _, err := hijacker.Hijack()
+						if err != nil {
+							t.Errorf("hijacking failed")
+							return
+						}
+
+						res := &http.Response{
+							StatusCode: http.StatusOK,
+							Proto:      "HTTP/1.1",
+							ProtoMajor: 1,
+							ProtoMinor: 1,
+							Header:     r.Header,
+						}
+
+						targetConn, err := net.Dial("tcp", r.URL.Host)
+						if err != nil {
+							t.Errorf("net.Dial(%q) failed: %v", r.URL.Host, err)
+							return
+						}
+
+						if err := res.Write(clientConn); err != nil {
+							t.Errorf("Writing 200 OK failed: %v", err)
+							return
+						}
+
+						go io.Copy(targetConn, clientConn)
+						go func() {
+							io.Copy(clientConn, targetConn)
+							targetConn.Close()
+						}()
+					}
+				}))
+			}
+
+			g.Before(func() {
+				createServer()
+			})
+
+			g.BeforeEach(func() {
+				ts.Close()
+				proxy.Close()
+				createServer()
+			})
+
+			g.After(func() {
+				ts.Close()
+				proxy.Close()
+			})
+
+			g.It("Should use Proxy Header authentication", func() {
+				res, err := Request{Uri: ts.URL,
+					Proxy:    proxy.URL,
+					Insecure: true,
+				}.WithProxyHeader("X-TEST-HEADER", "TEST").Do()
+				defer res.Body.Close()
+
+				var got *http.Request
+				select {
+				case got = <-proxyCh:
+				case <-time.After(5 * time.Second):
+					t.Fatal("timeout connecting to http proxy")
+				}
+
+				Expect(err).Should(BeNil())
+				Expect(res.StatusCode).Should(Equal(200))
+				str, _ := res.Body.ToString()
+				Expect(str).Should(Equal("Hello"))
+				Expect(got.Header.Get("X-TEST-HEADER")).Should(Equal("TEST"))
 			})
 
 		})


### PR DESCRIPTION
Correspondence to parameters added in Golang 1.9
I want to assign parameters to the header for authentication to the Proxy

https://github.com/golang/go/issues/19504